### PR TITLE
🧹 chore: remove unused shlex import in runners.py

### DIFF
--- a/src/orchestrator/runners.py
+++ b/src/orchestrator/runners.py
@@ -9,7 +9,6 @@ import subprocess
 import tempfile
 import time
 import psutil
-import shlex
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, List, Any
 from datetime import datetime


### PR DESCRIPTION
Cleaned up the unused `shlex` import from `src/orchestrator/runners.py` to improve code health and maintainability.

---
*PR created automatically by Jules for task [14649903839727262966](https://jules.google.com/task/14649903839727262966) started by @laurentvv*