### PR TITLE
🧪 Add unit tests for BenchmarkConfig in config.py

### DIFF
--- a/tests/unit/test_bench.config.json
+++ b/tests/unit/test_bench.config.json
@@ -1,0 +1,51 @@
+{
+  "languages": {
+    "python": {
+      "executable": "python",
+      "version_check": "--version",
+      "timeout": 240,
+      "file_extension": ".py",
+      "compile_required": false
+    },
+    "rust": {
+      "executable": "cargo",
+      "compile_cmd": "cargo build --release",
+      "version_check": "--version",
+      "timeout": 120,
+      "file_extension": ".rs",
+      "compile_required": true,
+      "binary_extension": ".exe"
+    }
+  },
+  "test_suites": {
+    "algorithms": {
+      "enabled": true,
+      "timeout": 30,
+      "iterations": 10,
+      "tests": ["fibonacci"]
+    },
+    "disabled_suite": {
+      "enabled": false,
+      "timeout": 20,
+      "iterations": 5,
+      "tests": ["test"]
+    }
+  },
+  "performance": {
+    "iterations": 10,
+    "warmup_runs": 2,
+    "timeout_per_test": 120,
+    "memory_sampling_interval": 0.1
+  },
+  "output": {
+    "format": "all",
+    "directory": "./results_test",
+    "timestamp": true,
+    "include_metadata": true
+  },
+  "system": {
+    "collect_system_info": true,
+    "monitor_resources": true,
+    "cleanup_binaries": false
+  }
+}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,48 @@
+import unittest
+import os
+import sys
+import shutil
+
+# Add src to Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
+
+from utils.config import BenchmarkConfig
+
+class TestBenchmarkConfig(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config_path = "tests/unit/test_bench.config.json"
+        cls.config = BenchmarkConfig(cls.config_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Clean up created output directory if it exists
+        if hasattr(cls, 'config') and os.path.exists(cls.config.output.directory):
+            shutil.rmtree(cls.config.output.directory)
+
+    def test_get_enabled_languages(self):
+        """Test that get_enabled_languages returns the correct list of languages."""
+        enabled_languages = self.config.get_enabled_languages()
+        self.assertIn("python", enabled_languages)
+        self.assertIn("rust", enabled_languages)
+        self.assertEqual(len(enabled_languages), 2)
+
+    def test_get_enabled_test_suites(self):
+        """Test that get_enabled_test_suites returns only enabled suites."""
+        enabled_suites = self.config.get_enabled_test_suites()
+        self.assertIn("algorithms", enabled_suites)
+        self.assertNotIn("disabled_suite", enabled_suites)
+        self.assertEqual(len(enabled_suites), 1)
+
+    def test_get_language_config(self):
+        """Test that get_language_config returns the correct configuration for a language."""
+        python_config = self.config.get_language_config("python")
+        self.assertIsNotNone(python_config)
+        self.assertEqual(python_config.executable, "python")
+        self.assertEqual(python_config.file_extension, ".py")
+
+        non_existent_config = self.config.get_language_config("non_existent")
+        self.assertIsNone(non_existent_config)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,7 +11,7 @@ from utils.config import BenchmarkConfig
 class TestBenchmarkConfig(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config_path = "tests/unit/test_bench.config.json"
+        cls.config_path = os.path.join(os.path.dirname(__file__), "test_bench.config.json")
         cls.config = BenchmarkConfig(cls.config_path)
 
     @classmethod


### PR DESCRIPTION
Implement missing unit tests for get_enabled_languages and other methods in BenchmarkConfig class. Created a dedicated tests/unit directory and a sample configuration file for testing.

---
*PR created automatically by Jules for task [3786039580491160039](https://jules.google.com/task/3786039580491160039) started by @laurentvv*