### PR TITLE
Refactor shared models and fix hacky PerformanceSummary import

### DIFF
--- a/src/orchestrator/core.py
+++ b/src/orchestrator/core.py
@@ -8,7 +8,6 @@ import sys
 import time
 import threading
 from typing import Dict, List, Optional, Any
-from dataclasses import dataclass, field
 from datetime import datetime
 import json
 
@@ -16,62 +15,12 @@ import json
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from utils.config import BenchmarkConfig, LanguageConfig, TestSuiteConfig
-
-
-@dataclass
-class TestResult:
-    """Single test execution result."""
-    execution_time: float
-    memory_usage: int
-    cpu_usage: float
-    output: str
-    error: str
-    success: bool
-    language: str
-    test_name: str
-    iteration: int
-    timestamp: datetime = field(default_factory=datetime.now)
-
-
-@dataclass
-class LanguagePerformance:
-    """Aggregated performance metrics for a language on a specific test."""
-    avg_time: float
-    min_time: float
-    max_time: float
-    std_time: float
-    avg_memory: float
-    peak_memory: int
-    avg_cpu: float
-    success_rate: float
-    total_iterations: int
-
-
-@dataclass
-class TestAnalysis:
-    """Analysis results for a specific test across all languages."""
-    test_name: str
-    language_performances: Dict[str, LanguagePerformance]
-    fastest_language: str
-    most_memory_efficient: str
-    most_reliable: str
-
-
-@dataclass
-class PerformanceSummary:
-    """Complete benchmark performance summary."""
-    benchmark_id: str
-    timestamp: datetime
-    total_tests: int
-    total_languages: int
-    total_executions: int
-    results: Dict[str, TestAnalysis]
-    overall_rankings: Any  # Can be OverallRankings object
-    execution_time: float
-    system_info: Dict[str, Any]
-    configuration: Dict[str, Any]
-    summary_statistics: Dict[str, Any]
-    language_versions: Dict[str, str] = field(default_factory=dict)
+from orchestrator.models import (
+    TestResult,
+    LanguagePerformance,
+    TestAnalysis,
+    PerformanceSummary
+)
 
 
 class BenchmarkOrchestrator:

--- a/src/orchestrator/metrics.py
+++ b/src/orchestrator/metrics.py
@@ -6,7 +6,10 @@ Monitors system resources and execution metrics during benchmark tests.
 import os
 import sys
 import time
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None
 import threading
 from typing import Dict, List, Optional, Any, Callable
 from dataclasses import dataclass, field
@@ -65,6 +68,8 @@ class MetricsCollector:
     
     def __init__(self, system_config: SystemConfig):
         self.config = system_config
+        if psutil is None:
+            self.config.monitor_resources = False
         self.monitoring_active = False
         self.monitoring_thread: Optional[threading.Thread] = None
         self.current_metrics: Optional[ExecutionMetrics] = None
@@ -90,7 +95,7 @@ class MetricsCollector:
         self.process_metrics_history.clear()
         
         # Set target process if provided
-        if process_id:
+        if process_id and psutil:
             try:
                 self.target_process = psutil.Process(process_id)
             except psutil.NoSuchProcess:
@@ -147,6 +152,8 @@ class MetricsCollector:
     
     def _collect_system_metrics(self) -> Optional[SystemMetrics]:
         """Collect current system metrics."""
+        if not psutil:
+            return None
         try:
             # CPU and memory
             cpu_percent = psutil.cpu_percent(interval=None)
@@ -257,7 +264,7 @@ class MetricsCollector:
     
     def get_current_system_info(self) -> Dict[str, Any]:
         """Get current system information."""
-        if not self.config.collect_system_info:
+        if not self.config.collect_system_info or not psutil:
             return {}
         
         try:
@@ -358,10 +365,13 @@ class SimpleMetricsCollector:
     def start(self) -> None:
         """Start timing."""
         self.start_time = time.perf_counter()
-        try:
-            process = psutil.Process()
-            self.peak_memory = process.memory_info().rss
-        except Exception:
+        if psutil:
+            try:
+                process = psutil.Process()
+                self.peak_memory = process.memory_info().rss
+            except Exception:
+                self.peak_memory = 0
+        else:
             self.peak_memory = 0
     
     def stop(self) -> Dict[str, float]:
@@ -372,12 +382,13 @@ class SimpleMetricsCollector:
         if self.start_time:
             execution_time = self.end_time - self.start_time
         
-        try:
-            process = psutil.Process()
-            current_memory = process.memory_info().rss
-            self.peak_memory = max(self.peak_memory, current_memory)
-        except Exception:
-            pass
+        if psutil:
+            try:
+                process = psutil.Process()
+                current_memory = process.memory_info().rss
+                self.peak_memory = max(self.peak_memory, current_memory)
+            except Exception:
+                pass
         
         return {
             'execution_time': execution_time,

--- a/src/orchestrator/models.py
+++ b/src/orchestrator/models.py
@@ -1,0 +1,84 @@
+"""
+Shared data models for the benchmark orchestrator.
+Consolidates dataclasses used across different modules.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional, Any, Tuple
+
+
+@dataclass
+class TestResult:
+    """Single test execution result."""
+    execution_time: float
+    memory_usage: int
+    cpu_usage: float
+    output: str
+    error: str
+    success: bool
+    language: str
+    test_name: str
+    iteration: int
+    timestamp: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class LanguagePerformance:
+    """Aggregated performance metrics for a language on a specific test."""
+    language: str
+    test_name: str
+    avg_time: float
+    min_time: float
+    max_time: float
+    std_time: float
+    median_time: float
+    avg_memory: float
+    peak_memory: int
+    min_memory: int
+    avg_cpu: float
+    max_cpu: float
+    success_rate: float
+    total_iterations: int
+    successful_iterations: int
+    performance_score: float = 0.0
+    reliability_score: float = 0.0
+
+
+@dataclass
+class TestAnalysis:
+    """Analysis results for a specific test across all languages."""
+    test_name: str
+    language_performances: Dict[str, LanguagePerformance]
+    fastest_language: str
+    most_memory_efficient: str
+    most_reliable: str
+    performance_ranking: List[Tuple[str, float]] = field(default_factory=list)
+    statistical_significance: Dict[str, Dict[str, float]] = field(default_factory=dict)
+
+
+@dataclass
+class OverallRankings:
+    """Overall performance rankings across all tests."""
+    by_speed: List[Tuple[str, float]]  # (language, avg_score)
+    by_memory: List[Tuple[str, float]]
+    by_reliability: List[Tuple[str, float]]
+    by_overall: List[Tuple[str, float]]
+    category_winners: Dict[str, str]  # test_category -> best_language
+
+
+@dataclass
+class PerformanceSummary:
+    """Complete benchmark performance summary."""
+    benchmark_id: str
+    timestamp: datetime
+    total_tests: int
+    total_languages: int
+    total_executions: int
+    results: Dict[str, TestAnalysis]
+    overall_rankings: OverallRankings
+    execution_time: float
+    system_info: Dict[str, Any]
+    configuration: Dict[str, Any]
+    summary_statistics: Dict[str, Any]
+    language_versions: Dict[str, str] = field(default_factory=dict)

--- a/src/orchestrator/reports.py
+++ b/src/orchestrator/reports.py
@@ -15,6 +15,7 @@ from dataclasses import asdict
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from utils.config import OutputConfig
+from orchestrator.models import PerformanceSummary
 
 
 class ReportGenerator:
@@ -29,7 +30,7 @@ class ReportGenerator:
         
         print(f" Report generator initialized (output: {self.config.directory})")
     
-    def generate_all_reports(self, performance_summary, formats: List[str] = None):
+    def generate_all_reports(self, performance_summary: PerformanceSummary, formats: List[str] = None):
         """Generate reports in all requested formats."""
         if formats is None:
             formats = ['json', 'html', 'csv']
@@ -64,7 +65,7 @@ class ReportGenerator:
         
         return generated_files
     
-    def generate_json_report(self, performance_summary) -> str:
+    def generate_json_report(self, performance_summary: PerformanceSummary) -> str:
         """Generate JSON format report."""
         file_path = os.path.join(
             self.config.directory,
@@ -80,7 +81,7 @@ class ReportGenerator:
         print(f"   JSON report: {os.path.basename(file_path)}")
         return file_path
     
-    def generate_html_report(self, performance_summary) -> str:
+    def generate_html_report(self, performance_summary: PerformanceSummary) -> str:
         """Generate HTML format report with visualizations."""
         file_path = os.path.join(
             self.config.directory,
@@ -95,7 +96,7 @@ class ReportGenerator:
         print(f"   HTML report: {os.path.basename(file_path)}")
         return file_path
     
-    def generate_csv_reports(self, performance_summary) -> List[str]:
+    def generate_csv_reports(self, performance_summary: PerformanceSummary) -> List[str]:
         """Generate CSV format reports."""
         file_paths = []
         
@@ -118,7 +119,7 @@ class ReportGenerator:
         print(f"   CSV reports: {len(file_paths)} files")
         return file_paths
     
-    def _prepare_json_data(self, performance_summary) -> Dict[str, Any]:
+    def _prepare_json_data(self, performance_summary: PerformanceSummary) -> Dict[str, Any]:
         """Prepare data for JSON serialization."""
         data = {
             'benchmark_info': {
@@ -184,7 +185,7 @@ class ReportGenerator:
         
         return data
     
-    def _generate_html_content(self, performance_summary) -> str:
+    def _generate_html_content(self, performance_summary: PerformanceSummary) -> str:
         """Generate HTML report content."""
         html_template = f"""
 <!DOCTYPE html>
@@ -359,7 +360,7 @@ class ReportGenerator:
         
         return html_template
     
-    def _generate_rankings_html(self, performance_summary) -> str:
+    def _generate_rankings_html(self, performance_summary: PerformanceSummary) -> str:
         """Generate HTML for overall rankings."""
         rankings = performance_summary.overall_rankings.by_overall
         
@@ -407,7 +408,7 @@ class ReportGenerator:
         
         return html
 
-    def _generate_versions_html(self, performance_summary) -> str:
+    def _generate_versions_html(self, performance_summary: PerformanceSummary) -> str:
         """Generate HTML for language versions."""
         versions = getattr(performance_summary, 'language_versions', {})
         if not versions:
@@ -431,7 +432,7 @@ class ReportGenerator:
         '''
         return html
     
-    def _generate_test_results_html(self, performance_summary) -> str:
+    def _generate_test_results_html(self, performance_summary: PerformanceSummary) -> str:
         """Generate HTML for individual test results."""
         if not performance_summary.results:
             return '<div class="section"><h2> Test Results</h2><p>No test results available.</p></div>'
@@ -507,7 +508,7 @@ class ReportGenerator:
         html += '</div>'
         return html
     
-    def _generate_comprehensive_csv(self, performance_summary, file_path: str):
+    def _generate_comprehensive_csv(self, performance_summary: PerformanceSummary, file_path: str):
         """Generate comprehensive CSV report."""
         with open(file_path, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
@@ -553,7 +554,7 @@ class ReportGenerator:
                         round(perf.reliability_score, 2)
                     ])
     
-    def _generate_rankings_csv(self, performance_summary, file_path: str):
+    def _generate_rankings_csv(self, performance_summary: PerformanceSummary, file_path: str):
         """Generate rankings CSV report."""
         with open(file_path, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)

--- a/src/orchestrator/results.py
+++ b/src/orchestrator/results.py
@@ -7,87 +7,19 @@ import os
 import sys
 import statistics
 from typing import Dict, List, Optional, Any, Tuple
-from dataclasses import dataclass, field
 from datetime import datetime
 import math
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
-
-@dataclass
-class TestResult:
-    """Single test execution result."""
-    execution_time: float
-    memory_usage: int
-    cpu_usage: float
-    output: str
-    error: str
-    success: bool
-    language: str
-    test_name: str
-    iteration: int
-    timestamp: datetime = field(default_factory=datetime.now)
-
-
-@dataclass
-class LanguagePerformance:
-    """Aggregated performance metrics for a language on a specific test."""
-    language: str
-    test_name: str
-    avg_time: float
-    min_time: float
-    max_time: float
-    std_time: float
-    median_time: float
-    avg_memory: float
-    peak_memory: int
-    min_memory: int
-    avg_cpu: float
-    max_cpu: float
-    success_rate: float
-    total_iterations: int
-    successful_iterations: int
-    performance_score: float = 0.0
-    reliability_score: float = 0.0
-
-
-@dataclass
-class TestAnalysis:
-    """Analysis results for a specific test across all languages."""
-    test_name: str
-    language_performances: Dict[str, LanguagePerformance]
-    fastest_language: str
-    most_memory_efficient: str
-    most_reliable: str
-    performance_ranking: List[Tuple[str, float]]  # (language, score)
-    statistical_significance: Dict[str, Dict[str, float]]  # language comparisons
-
-
-@dataclass
-class OverallRankings:
-    """Overall performance rankings across all tests."""
-    by_speed: List[Tuple[str, float]]  # (language, avg_score)
-    by_memory: List[Tuple[str, float]]
-    by_reliability: List[Tuple[str, float]]
-    by_overall: List[Tuple[str, float]]
-    category_winners: Dict[str, str]  # test_category -> best_language
-
-
-@dataclass
-class PerformanceSummary:
-    """Complete benchmark performance summary."""
-    benchmark_id: str
-    timestamp: datetime
-    total_tests: int
-    total_languages: int
-    total_executions: int
-    results: Dict[str, TestAnalysis]
-    overall_rankings: OverallRankings
-    execution_time: float
-    system_info: Dict[str, Any]
-    configuration: Dict[str, Any]
-    summary_statistics: Dict[str, Any]
+from orchestrator.models import (
+    TestResult,
+    LanguagePerformance,
+    TestAnalysis,
+    OverallRankings,
+    PerformanceSummary
+)
 
 
 class ResultsCompiler:
@@ -133,12 +65,6 @@ class ResultsCompiler:
         # Generate summary statistics
         summary_stats = self._generate_summary_statistics(test_analyses, raw_results)
 
-        # The PerformanceSummary is defined in core.py, but we construct it here.
-        # We need to import it properly if it's not available.
-        # For now, let's assume it's available via the context it's called in.
-        # This is a bit of a hack, but let's proceed.
-        from orchestrator.core import PerformanceSummary
-        
         performance_summary = PerformanceSummary(
             benchmark_id=benchmark_id,
             timestamp=datetime.now(),

--- a/src/orchestrator/runners.py
+++ b/src/orchestrator/runners.py
@@ -8,7 +8,10 @@ import sys
 import subprocess
 import tempfile
 import time
-import psutil
+try:
+    import psutil
+except ImportError:
+    psutil = None
 import shlex
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, List, Any
@@ -18,23 +21,7 @@ from datetime import datetime
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from utils.config import BenchmarkConfig, LanguageConfig
-
-
-class TestResult:
-    """Test execution result with performance metrics."""
-    def __init__(self, execution_time: float, memory_usage: int, cpu_usage: float,
-                 output: str, error: str, success: bool, language: str, 
-                 test_name: str, iteration: int):
-        self.execution_time = execution_time
-        self.memory_usage = memory_usage
-        self.cpu_usage = cpu_usage
-        self.output = output
-        self.error = error
-        self.success = success
-        self.language = language
-        self.test_name = test_name
-        self.iteration = iteration
-        self.timestamp = datetime.now()
+from orchestrator.models import TestResult
 
 
 class BaseLanguageRunner(ABC):
@@ -104,6 +91,8 @@ class BaseLanguageRunner(ABC):
     def _monitor_process_metrics(self, process: subprocess.Popen, 
                                duration: float) -> Dict[str, float]:
         """Monitor process metrics during execution."""
+        if not psutil:
+            return {'peak_memory': 0, 'avg_cpu': 0.0}
         try:
             psutil_process = psutil.Process(process.pid)
             initial_memory = psutil_process.memory_info().rss


### PR DESCRIPTION
This change refactors the core data structures used by the benchmark orchestrator into a dedicated `models.py` file. This resolves the issue where `PerformanceSummary` had to be imported inline in `results.py` to avoid a circular dependency with `core.py`. 

Key changes:
- Created `src/orchestrator/models.py` containing consolidated dataclass definitions.
- Updated `src/orchestrator/results.py`, `src/orchestrator/core.py`, `src/orchestrator/runners.py`, and `src/orchestrator/reports.py` to use these shared models.
- Removed multiple redundant definitions of `TestResult`.
- Added defensive `psutil` imports to `metrics.py` and `runners.py` to allow the orchestrator to run even if the package is missing.
- Verified the fix by running a sample benchmark.

---
*PR created automatically by Jules for task [12446928837594496601](https://jules.google.com/task/12446928837594496601) started by @laurentvv*