### PR TITLE
🧹 Remove unused import asdict in reports.py

### DIFF
--- a/src/orchestrator/reports.py
+++ b/src/orchestrator/reports.py
@@ -9,7 +9,6 @@ import json
 import csv
 from typing import Dict, List, Optional, Any
 from datetime import datetime
-from dataclasses import asdict
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed the unused `asdict` import from `src/orchestrator/reports.py`.

💡 **Why:** How this improves maintainability
- Removing unused imports reduces clutter in the codebase, improves readability, and avoids unnecessary dependency tracking during code analysis.

✅ **Verification:** How you confirmed the change is safe
- Performed a syntax check using `python3 -m py_compile src/orchestrator/reports.py`.
- Ran existing unit tests using `python3 -m unittest discover tests/unit`.
- All checks passed successfully.

✨ **Result:** The improvement achieved
- A cleaner and more maintainable `reports.py` file without dead code.

---
*PR created automatically by Jules for task [5301324250204268930](https://jules.google.com/task/5301324250204268930) started by @laurentvv*